### PR TITLE
Matrix docs talk about vectors

### DIFF
--- a/docs/clay/vector_matrix.qmd
+++ b/docs/clay/vector_matrix.qmd
@@ -3054,7 +3054,7 @@ $\mathbf{C} = \mathbf{A}^T \mathbf{B}^T$
 
 A wide range of element-wise mathematical functions (e.g., `sin`, `cos`, `pow`) are provided, mirroring those in `fastmath.vector`.
 
-`fmap` applies a function to each element of the vector, returning a new vector of the same type.
+`fmap` applies a function to each element of the matrix, returning a new matrix of the same type.
 
 ::: {.callout-tip title="Defined functions"}
 * `sin`, `cos`, `tan`, `asin`, `acos`, `atan`

--- a/docs/clay/vector_matrix.qmd
+++ b/docs/clay/vector_matrix.qmd
@@ -3052,7 +3052,7 @@ $\mathbf{C} = \mathbf{A}^T \mathbf{B}^T$
 
 #### Element-wise Operations
 
-A wide range of element-wise mathematical functions (e.g., `sin`, `cos`, `pow`) are provided, mirroring those in `fastmath.vector`.
+A wide range of element-wise mathematical functions (e.g., `sin`, `cos`) are provided, mirroring those in `fastmath.vector`.
 
 `fmap` applies a function to each element of the matrix, returning a new matrix of the same type.
 


### PR DESCRIPTION
Hi :)

Reading the fastmath docs for [Matrix Arithmetic and Operations/Element-wise Operations][1], I found it to mention vectors, not matrices. Also, `fastmath.matrix/pow` doesn't seem to exist.

[1]: https://generateme.github.io/fastmath/clay/vector_matrix.html#element-wise-operations

